### PR TITLE
Update for 2022-12-01 TF2 update

### DIFF
--- a/pda_click.sp
+++ b/pda_click.sp
@@ -20,7 +20,9 @@ public void OnPluginStart() {
 }
 
 public Action PlayerAnimEvent(const char[] te_name, const int[] clients, int numClients, float delay) {
-	int client = TE_ReadNum("m_iPlayerIndex");
+	int ehandle = TE_ReadNum("m_hPlayer");
+	int client = ehandle & ((1<<11) - 1);
+	
 	if (client <= 0 || client > MaxClients || !IsClientInGame(client) || !IsPlayerAlive(client)) {
 		return Plugin_Continue;
 	}
@@ -52,7 +54,7 @@ public Action PlayerAnimEvent(const char[] te_name, const int[] clients, int num
 	//resend the event with the sending client added to recipients
 	clResult[numClients] = client;
 	TE_Start("PlayerAnimEvent");
-	TE_WriteNum("m_iPlayerIndex", client);
+	TE_WriteNum("m_hPlayer", ehandle);
 	TE_WriteNum("m_iEvent", event);
 	TE_WriteNum("m_nData", data);
 	TE_Send(clResult, numClients+1, delay);


### PR DESCRIPTION
CTEPlayerAnimEvent now uses an EHandle rather than an entity index.

EntRefToEntIndex is not usable here because the tempent hook fires after SendProxy_EHandleToInt is applied.