### PR TITLE
Convert m_hPlayer with EntRefToEntIndex instead of bitmask

### DIFF
--- a/pda_click.sp
+++ b/pda_click.sp
@@ -21,7 +21,7 @@ public void OnPluginStart() {
 
 public Action PlayerAnimEvent(const char[] te_name, const int[] clients, int numClients, float delay) {
 	int ehandle = TE_ReadNum("m_hPlayer");
-	int client = ehandle & ((1<<11) - 1);
+	int client = EntRefToEntIndex(ehandle | (1<<31));
 	
 	if (client <= 0 || client > MaxClients || !IsClientInGame(client) || !IsPlayerAlive(client)) {
 		return Plugin_Continue;


### PR DESCRIPTION
Convert m_hPlayer to a client index by setting the high bit and passing it to EntRefToEntIndex, instead of using a bitmask.